### PR TITLE
Fix broken markdown table upon Jekyll render

### DIFF
--- a/_docs/transports-http.md
+++ b/_docs/transports-http.md
@@ -25,6 +25,7 @@ npm install ht-http-transport --save
 | ssl     | Object     |          | { cert, key } | N/A       | Enable SSL                             |
 | agent   | http.Agent |          |               | N/A       | To manage connection persistence       |
 | timeout | number     |          | 1800          | N/A       | Timeout before the socket is connected |
+
 ## Example
 
 ```js


### PR DESCRIPTION
This PR adds a line break between markdown table and next header.

The [HTTP Transport page](https://hudson-taylor.github.io/docs/transports/http/) displaying the options table is broken. I suspect it is related to a missing line break, because the [TCP Transport page](https://hudson-taylor.github.io/docs/transports/tcp/) renders correctly with a line break in between.

_screenshot of broken markdown table_ |
---|
![image](https://user-images.githubusercontent.com/8832106/75165380-45a15f00-575d-11ea-9711-3b47432fb8b8.png) |